### PR TITLE
Ignore invalid tags

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -1,22 +1,22 @@
 module.exports =
 {
     badCurrentRef(ref) {
-        throw `The current version tag "${ref}" does not contain a valid Semantic Version. This was probably either ` +
+        return `The current version tag "${ref}" does not contain a valid Semantic Version. This was probably either ` +
               `a typo or an accidental push.`;
     },
 
     nonHighest(currentVersion, highestVersion) {
-        throw `The current version "${currentVersion}" is not the highest version "${highestVersion}" in the ` +
+        return `The current version "${currentVersion}" is not the highest version "${highestVersion}" in the ` +
               `repository. This indicates that you are attempting to push a version that is lower than a previous one.`;
     },
 
     badBranch(branch, ref) {
-        throw `The "${branch}" branch does not contain the current version tag "${ref}. You may have created the ` +
+        return `The "${branch}" branch does not contain the current version tag "${ref}. You may have created the ` +
               `tag on the wrong branch.`;
     },
 
     badVersionTag(tag, glob) {
-        throw `The repository contains the version tag "${tag}", which is not a valid Semantic Version. All tags ` +
+        return `The repository contains the version tag "${tag}", which is not a valid Semantic Version. All tags ` +
               `matched by the glob "${glob}" must be valid Semantic Versions.`;
     }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,20 +10,20 @@ async function main() {
         const version = semver.clean(ref);
 
         if(!semver.valid(version)) {
-            error.badCurrentRef(ref);
+            throw error.badCurrentRef(ref);
         }
 
         const allVersions = await getVersions();
         const highestVersion = allVersions[0];
 
         if (!semver.eq(highestVersion, version)) {
-            error.nonHighest(version, highestVersion);
+            throw error.nonHighest(version, highestVersion);
         }
 
         const branch = core.getInput('branch');
 
         if(! await branchContains(branch, ref)) {
-            error.badBranch(branch, ref);
+            throw error.badBranch(branch, ref);
         }
 
         core.setOutput('current_version', version);

--- a/src/versions.js
+++ b/src/versions.js
@@ -11,14 +11,15 @@ async function getTags(glob) {
 module.exports = async function() {
     const glob = core.getInput('tags');
     const tags = await getTags(glob);
-    const versions = tags.map(function(tag) {
+    const versions = tags.flatMap(function(tag) {
         const cleaned = semver.clean(tag);
 
         if (!semver.valid(cleaned)) {
-            error.badVersionTag(tag, glob);
+            core.warning(error.badVersionTag(tag, glob));
+            return [];
         }
 
-        return cleaned;
+        return [cleaned];
     });
     versions.sort((a, b) => semver.compare(b, a));
 


### PR DESCRIPTION
Rather than throwing errors on invalid version tags, switch to logging a warning and ignoring it.

This resolves #8.